### PR TITLE
:sparkles: feat: 만료시간이 된 챌린지들은 삭제되도록 스케줄링 구현

### DIFF
--- a/src/main/java/com/example/TCC/TccApplication.java
+++ b/src/main/java/com/example/TCC/TccApplication.java
@@ -2,8 +2,10 @@ package com.example.TCC;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TccApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/TCC/dto/response/TryChallengeResponseDto.java
+++ b/src/main/java/com/example/TCC/dto/response/TryChallengeResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.TCC.dto.response;
+
+import com.example.TCC.domain.TryChall;
+
+import java.time.LocalDateTime;
+
+public class TryChallengeResponseDto {
+    private Long id;
+    private String memberName;
+    private String memberProfile;
+    private LocalDateTime startTime;
+    private LocalDateTime expireTime;
+    private String challengeTitle;
+    private String challengeImg;
+
+    public static DrawChallengeResponseDto createDrawChallengeDto(TryChall tryChall) {
+
+        return new DrawChallengeResponseDto(
+                tryChall.getId(),
+                tryChall.getMember().getNickname(),
+                tryChall.getMember().getProfileImg(),
+                tryChall.getStartTime(),
+                tryChall.getExpireTime(),
+                tryChall.getChallenge().getTitle(),
+                tryChall.getChallenge().getCategory().getCategoryImg()
+        );
+    }
+}

--- a/src/main/java/com/example/TCC/repository/TryChallRepository.java
+++ b/src/main/java/com/example/TCC/repository/TryChallRepository.java
@@ -4,6 +4,7 @@ import com.example.TCC.domain.Member;
 import com.example.TCC.domain.TryChall;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface TryChallRepository extends JpaRepository<TryChall, Long> {
@@ -13,4 +14,6 @@ public interface TryChallRepository extends JpaRepository<TryChall, Long> {
     Optional<TryChall> findByMemberAndExpireTimeIsNull(Member member);
 
     Optional<TryChall> findByMember(Member member);
+
+    void deleteByExpireTimeBefore(LocalDateTime now);
 }

--- a/src/main/java/com/example/TCC/service/ChallengeExpireService.java
+++ b/src/main/java/com/example/TCC/service/ChallengeExpireService.java
@@ -1,0 +1,25 @@
+package com.example.TCC.service;
+
+import com.example.TCC.repository.TryChallRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChallengeExpireService {
+
+    private final TryChallRepository tryChallRepository;
+
+    //매초마다 실행되는 스케줄러
+    @Scheduled(fixedRate = 1000)
+    public void deleteExpiredChallenges() {
+        //현재 시간보다 expireTime이 이전인 모든 TryChall 인스턴스 찾아 삭제
+        LocalDateTime now = LocalDateTime.now();
+        tryChallRepository.deleteByExpireTimeBefore(now);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,8 @@ spring:
     password: jwt1234
   thymeleaf:
     cache: false
+  main:
+    allow-bean-definition-overriding: true
 
 
   # spring data jpa 설정
@@ -32,3 +34,4 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+    open-in-view: false


### PR DESCRIPTION
## 📚개요
만료시간이 된 챌린지들은 db에서 자동으로 삭제되도록 스케줄링 사용하여 구현했습니다.

## 💡Key Changes
만료시간이 된 챌린지들은 챌린지 도전 테이블에서 자동으로 삭제되도록 하였습니다.

## 🎓Reference

