### PR TITLE
refactor: 챌린지 도전 만료시간 수정

### DIFF
--- a/src/main/java/com/example/TCC/service/ChallengeService.java
+++ b/src/main/java/com/example/TCC/service/ChallengeService.java
@@ -78,7 +78,7 @@ public class ChallengeService {
 
         //만료시간 설정해주기 (시작시간으로부터 24시간 뒤)
         if (tryChall.getStartTime() != null) {
-            LocalDateTime expireTime = tryChall.getStartTime().plus(Duration.ofSeconds(24));
+            LocalDateTime expireTime = tryChall.getStartTime().plus(Duration.ofHours(24));
             tryChall.setExpireTime(expireTime);
         } else {
             //시작시간이 설정되어 있지 않는 경우


### PR DESCRIPTION
## 📚개요
챌린지 도전 만료시간을 24시간으로 수정했습니다.

## 💡Key Changes
챌린지 도전 만료시간을 24시간으로 수정했습니다.

## 🎓Reference

