### PR TITLE
:sparkles: feat: accessToken 재발급 및 로그아웃 로직 구현

### DIFF
--- a/src/main/java/com/example/TCC/controller/AuthController.java
+++ b/src/main/java/com/example/TCC/controller/AuthController.java
@@ -1,26 +1,43 @@
 package com.example.TCC.controller;
 
+import com.example.TCC.domain.Member;
+import com.example.TCC.dto.response.AccessTokenGetSuccess;
 import com.example.TCC.kakao.KakaoApiClient;
 import com.example.TCC.kakao.KakaoLoginParams;
 import com.example.TCC.kakao.jwt.AuthTokens;
+import com.example.TCC.service.MemberService;
 import com.example.TCC.service.OAuthLoginService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 public class AuthController {
     private final OAuthLoginService oAuthLoginService;
     private final KakaoApiClient kakaoApiClient;
+    private final MemberService memberService;
 
     //카카오 로그인
     @PostMapping("/login")
     public ResponseEntity<AuthTokens> loginKakao(@RequestBody KakaoLoginParams params) {
         return ResponseEntity.ok(oAuthLoginService.login(params));
+    }
+
+    //accessToken 재발급 (Bearer 없이 param으로)
+    @PostMapping("/refresh")
+    public ResponseEntity<AccessTokenGetSuccess> refresh(@RequestParam("refreshToken") String refreshToken) {
+        AccessTokenGetSuccess accessToken = oAuthLoginService.refreshToken(refreshToken);
+        return ResponseEntity.ok(accessToken);
+    }
+
+    //로그아웃 (Bearer과 함께 header로)
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestHeader("Authorization") String authorizationHeader) {
+        Member member = memberService.getCurrentUser(authorizationHeader);
+
+        oAuthLoginService.logout(member);
+        return ResponseEntity.ok("로그아웃 완료");
     }
 }

--- a/src/main/java/com/example/TCC/domain/Member.java
+++ b/src/main/java/com/example/TCC/domain/Member.java
@@ -30,12 +30,16 @@ public class Member {
     @Column
     private OAuthProvider oAuthProvider;
 
+    @Column
+    private String refreshToken;
+
     @Builder
-    public Member(String email, String nickname, String profileUrl, OAuthProvider oAuthProvider) {
+    public Member(String email, String nickname, String profileUrl, OAuthProvider oAuthProvider, String refreshToken) {
         this.email = email;
         this.nickname = nickname;
         this.profileImg = profileUrl;
         this.oAuthProvider = oAuthProvider;
+        this.refreshToken = refreshToken;
     }
 
     public void patch(NicknameRequestDto dto) {

--- a/src/main/java/com/example/TCC/dto/SuccessMessage.java
+++ b/src/main/java/com/example/TCC/dto/SuccessMessage.java
@@ -1,0 +1,17 @@
+package com.example.TCC.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+    SIGNUP_SUCCESS(HttpStatus.OK.value(), "회원 가입이 완료되었습니다."),
+    ISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK.value(), "액세스 토큰 재발급이 완료되었습니다."),
+    USER_DELETE_SUCCESS(HttpStatus.OK.value(), "회원 삭제가 완료되었습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK.value(), "로그아웃이 완료되었습니다.")
+    ;
+    int status;
+    String message;
+}

--- a/src/main/java/com/example/TCC/dto/SuccessResponse.java
+++ b/src/main/java/com/example/TCC/dto/SuccessResponse.java
@@ -1,0 +1,27 @@
+package com.example.TCC.dto;
+
+public record SuccessResponse<T>(
+        int status,
+        String message,
+        T data
+) {
+    public static <T> SuccessResponse<T> of(
+            final SuccessMessage successMessage,
+            final T data
+    ) {
+        return new SuccessResponse<T>(
+                successMessage.getStatus(),
+                successMessage.getMessage(),
+                data);
+    }
+
+    public static SuccessResponse of(
+            final SuccessMessage successMessage
+    ) {
+        return new SuccessResponse(
+                successMessage.getStatus(),
+                successMessage.getMessage(),
+                ""
+        );
+    }
+}

--- a/src/main/java/com/example/TCC/dto/response/AccessTokenGetSuccess.java
+++ b/src/main/java/com/example/TCC/dto/response/AccessTokenGetSuccess.java
@@ -1,0 +1,11 @@
+package com.example.TCC.dto.response;
+
+public record AccessTokenGetSuccess(
+        String accessToken
+) {
+    public static AccessTokenGetSuccess of(
+            final String accessToken
+    ) {
+        return new AccessTokenGetSuccess(accessToken);
+    }
+}

--- a/src/main/java/com/example/TCC/kakao/jwt/AuthTokensGenerator.java
+++ b/src/main/java/com/example/TCC/kakao/jwt/AuthTokensGenerator.java
@@ -47,8 +47,9 @@ import org.springframework.stereotype.Component;
 public class AuthTokensGenerator {
     private static final String BEARER_TYPE = "Bearer";
     // 만료 시간을 밀리초 단위로 설정
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60; // 30분
+//    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 2; // 7일
 
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/example/TCC/service/OAuthLoginService.java
+++ b/src/main/java/com/example/TCC/service/OAuthLoginService.java
@@ -1,11 +1,14 @@
 package com.example.TCC.service;
 
 import com.example.TCC.domain.Member;
+import com.example.TCC.dto.response.AccessTokenGetSuccess;
+import com.example.TCC.exception.UnAuthorizedException;
 import com.example.TCC.kakao.OAuthInfoResponse;
 import com.example.TCC.kakao.OAuthLoginParams;
 import com.example.TCC.kakao.RequestOAuthInfoService;
 import com.example.TCC.kakao.jwt.AuthTokens;
 import com.example.TCC.kakao.jwt.AuthTokensGenerator;
+import com.example.TCC.kakao.jwt.JwtTokenProvider;
 import com.example.TCC.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,11 +19,20 @@ public class OAuthLoginService {
     private final MemberRepository memberRepository;
     private final AuthTokensGenerator authTokensGenerator;
     private final RequestOAuthInfoService requestOAuthInfoService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public AuthTokens login(OAuthLoginParams params) {
         OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
         Long memberId = findOrCreateMember(oAuthInfoResponse);
-        return authTokensGenerator.generate(memberId);
+        AuthTokens authTokens = authTokensGenerator.generate(memberId);
+
+        // refreshToken 업데이트
+        memberRepository.findById(memberId).ifPresent(member -> {
+            member.setRefreshToken(authTokens.getRefreshToken());
+            memberRepository.save(member);
+        });
+
+        return authTokens;
     }
 
     private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
@@ -38,5 +50,31 @@ public class OAuthLoginService {
                 .build();
 
         return memberRepository.save(member).getId();
+    }
+
+    public AccessTokenGetSuccess refreshToken(final String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new UnAuthorizedException("토큰이 유효하지 않습니다.");
+        }
+
+        Long userId = Long.valueOf(jwtTokenProvider.getSubject(refreshToken));
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new UnAuthorizedException("멤버가 없습니다."));
+
+        // DB에 저장된 refreshToken과 일치하는지 검사
+        if (!refreshToken.equals(member.getRefreshToken())) {
+            throw new UnAuthorizedException("TOKEN_INCORRECT_ERROR");
+        }
+
+        // 새로운 accessToken 생성 (refreshToken은 유지)
+        String newAccessToken = jwtTokenProvider.generateToken(userId.toString(), AuthTokensGenerator.ACCESS_TOKEN_EXPIRE_TIME);
+
+        // 새로운 accessToken을 반환하는 DTO 객체 생성
+        return AccessTokenGetSuccess.of(newAccessToken);
+    }
+
+    public void logout(Member member) {
+            member.setRefreshToken(null); // 또는 적절한 무효화 방법 선택
+            memberRepository.save(member);
     }
 }


### PR DESCRIPTION
## 📚개요
accessToken 재발급 및 로그아웃 로직 구현

## 💡Key Changes
accessToken이 만료되었을 때 refreshToken을 통해 accessToken을 재발급해주었습니다.
또한 로그아웃 요청시 refreshToken을 삭제해줌으로써 다시 accessToken을 발급받을 수 없도록 해주었습니다.

## 🎓Reference
