### PR TITLE
:sparkles: feat: 챌린지 완료 구현

### DIFF
--- a/src/main/java/com/example/TCC/controller/ChallengeController.java
+++ b/src/main/java/com/example/TCC/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.example.TCC.controller;
 
 import com.example.TCC.domain.Member;
 import com.example.TCC.dto.request.DrawChallengeRequestDto;
+import com.example.TCC.dto.response.CompleteChallengeResponseDto;
 import com.example.TCC.dto.response.DrawChallengeResponseDto;
 import com.example.TCC.dto.response.TryChallengeResponseDto;
 import com.example.TCC.service.ChallengeService;
@@ -39,7 +40,7 @@ public class ChallengeController {
          return ResponseEntity.status(HttpStatus.OK).body("챌린지에 도전하셨습니다.");
     }
 
-    //챌린지 도전항목 조회
+    //챌린지 도전항목 조회 (오챌완 버튼도 이걸로)
     @GetMapping("/try/check")
     public ResponseEntity<TryChallengeResponseDto> tryCheck(@RequestHeader("Authorization") String authorizationHeader) {
         //로그인한 사용자가 있는지 확인
@@ -49,4 +50,17 @@ public class ChallengeController {
         return ResponseEntity.status(HttpStatus.OK).body(tryDto);
     }
 
+    //챌린지 완료
+    @PostMapping("/complete")
+    public ResponseEntity<CompleteChallengeResponseDto> complete(@RequestHeader("Authorization") String authorizationHeader) {
+        //로그인한 사용자가 있는지 확인
+        Member member = memberService.getCurrentUser(authorizationHeader);
+
+        CompleteChallengeResponseDto completeDto = challengeService.complete(member);
+        return ResponseEntity.status(HttpStatus.OK).body(completeDto);
+    }
+
+    //완료한 챌린지 전체 조회
+
+    //완료한 챌린지 상세 조회
 }

--- a/src/main/java/com/example/TCC/domain/CompleteChall.java
+++ b/src/main/java/com/example/TCC/domain/CompleteChall.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Getter
@@ -20,9 +21,45 @@ public class CompleteChall {
     private Long id;
 
     @Column
+    private Long memberId;
+
+    @Column
+    private String nickname;
+
+    @Column
+    private String memberProfileImg;
+
+    @Column
+    private LocalDateTime startTime;
+
+    @Column
     private LocalDateTime completeTime;
 
-    @OneToOne
-    @JoinColumn(name = "tryChall_id")
-    private TryChall tryChall;
+    @Column
+    private Duration takenTime;
+
+    @Column
+    private String challengeTitle;
+
+    @Column
+    private String challengeImg;
+
+//    @OneToOne
+//    @JoinColumn(name = "tryChall_id")
+//    private TryChall tryChall;
+
+    public static CompleteChall create(TryChall tryChall) {
+
+        return new CompleteChall(
+                null,
+                tryChall.getMember().getId(),
+                tryChall.getNickname(),
+                tryChall.getMember().getProfileImg(),
+                tryChall.getStartTime(),
+                LocalDateTime.now(),
+                Duration.between(tryChall.getStartTime(), LocalDateTime.now()),
+                tryChall.getChallenge().getTitle(),
+                tryChall.getChallenge().getCategory().getCategoryImg()
+        );
+    }
 }

--- a/src/main/java/com/example/TCC/dto/response/CompleteChallengeResponseDto.java
+++ b/src/main/java/com/example/TCC/dto/response/CompleteChallengeResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.TCC.dto.response;
+
+import com.example.TCC.domain.CompleteChall;
+import com.example.TCC.domain.TryChall;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CompleteChallengeResponseDto {
+    private String memberName;
+    private String memberProfile;
+    private LocalDateTime startTime;
+    private LocalDateTime completeTime;
+    private Duration takenTime;
+    private String challengeTitle;
+    private String challengeImg;
+
+    public static CompleteChallengeResponseDto createCompleteChallengeDto(CompleteChall completeChall) {
+
+        return new CompleteChallengeResponseDto(
+                completeChall.getNickname(),
+                completeChall.getMemberProfileImg(),
+                completeChall.getStartTime(),
+                completeChall.getCompleteTime(),
+                completeChall.getTakenTime(),
+                completeChall.getChallengeTitle(),
+                completeChall.getChallengeImg()
+        );
+    }
+}

--- a/src/main/java/com/example/TCC/service/ChallengeService.java
+++ b/src/main/java/com/example/TCC/service/ChallengeService.java
@@ -1,16 +1,15 @@
 package com.example.TCC.service;
 
-import com.example.TCC.domain.Category;
-import com.example.TCC.domain.Challenge;
-import com.example.TCC.domain.Member;
-import com.example.TCC.domain.TryChall;
+import com.example.TCC.domain.*;
 import com.example.TCC.dto.request.DrawChallengeRequestDto;
+import com.example.TCC.dto.response.CompleteChallengeResponseDto;
 import com.example.TCC.dto.response.DrawChallengeResponseDto;
 import com.example.TCC.dto.response.TryChallengeResponseDto;
 import com.example.TCC.exception.ConflictException;
 import com.example.TCC.exception.NotFoundException;
 import com.example.TCC.repository.CategoryRepository;
 import com.example.TCC.repository.ChallengeRepository;
+import com.example.TCC.repository.CompleteChallRepository;
 import com.example.TCC.repository.TryChallRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +29,7 @@ public class ChallengeService {
     private final TryChallRepository tryChallRepository;
     private final ChallengeRepository challengeRepository;
     private final CategoryRepository categoryRepository;
+    private final CompleteChallRepository completeChallRepository;
 
     //챌린지 뽑기
     public DrawChallengeResponseDto draw(DrawChallengeRequestDto dto, Member member) {
@@ -103,6 +103,23 @@ public class ChallengeService {
             throw new NotFoundException("도전 중인 챌린지가 없습니다.");
 
         TryChallengeResponseDto dto = TryChallengeResponseDto.createTryChallengeDto(tryChall);
+
+        return dto;
+    }
+
+    //챌린지 완료
+    public CompleteChallengeResponseDto complete(Member member) {
+
+        //멤버에 해당하는 챌린지 가져오기
+        TryChall tryChall = tryChallRepository.findByMember(member)
+                .orElseThrow( () -> new NotFoundException("완료할 챌린지가 없습니다."));
+
+        CompleteChall completeChall = CompleteChall.create(tryChall);
+        CompleteChall complete = completeChallRepository.save(completeChall);
+
+        tryChallRepository.delete(tryChall);
+
+        CompleteChallengeResponseDto dto = CompleteChallengeResponseDto.createCompleteChallengeDto(complete);
 
         return dto;
     }


### PR DESCRIPTION
## 📚개요
챌린지 완료 구현했습니다.

## 💡Key Changes
챌린지를 완료하면 챌린지 완료 테이블에 해당 정보를 저장하고, 챌린지 도전 테이블에서 도전이 끝난 인스턴스를 삭제해주었습니다.
걸린시간 표시 작업은 더 구현해야 합니다.

## 🎓Reference
참고한 문서나 자료의 링크를 첨부합니다.
