### PR TITLE
:recycle: refactor: 챌린지 완료 테이블에서 memberId를 직접 저장하는 것에서 member 테이블과 매핑하는 것으로 수정

### DIFF
--- a/src/main/java/com/example/TCC/domain/CompleteChall.java
+++ b/src/main/java/com/example/TCC/domain/CompleteChall.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -20,8 +22,10 @@ public class CompleteChall {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
 
     @Column
     private String nickname;
@@ -52,7 +56,7 @@ public class CompleteChall {
 
         return new CompleteChall(
                 null,
-                tryChall.getMember().getId(),
+                tryChall.getMember(),
                 tryChall.getNickname(),
                 tryChall.getMember().getProfileImg(),
                 tryChall.getStartTime(),


### PR DESCRIPTION
## 📚개요
CompleteChall(챌린지 완료) 테이블에서  memberId를 직접 저장하는 것에서 member 테이블과 매핑하는 것으로 수정하였습니다.

## 💡Key Changes
멤버(회원)가 탈퇴하면 해당 멤버의 챌린지 완료 목록도 cascade로 delete될 수 있도록 CompleteChall(챌린지 완료) 테이블에서  memberId를 직접 저장하는 것에서 member 테이블과 매핑하는 것으로 수정하였습니다.

## 🎓Reference
참고한 문서나 자료의 링크를 첨부합니다.
